### PR TITLE
Removed "by [name] on [date]" message - github does this automatically

### DIFF
--- a/src/main/java/frc/robot/sensors/IrSensor.java
+++ b/src/main/java/frc/robot/sensors/IrSensor.java
@@ -5,10 +5,6 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-/**
- * Charlie MacDonald.
- * Last modified on Feb 8th, 2020.
- */
 
 package frc.robot.sensors;
 
@@ -76,5 +72,5 @@ public class IrSensor implements Sendable {
 	public void initSendable(SendableBuilder builder) {
         builder.addDoubleProperty("Distance", this::getDistance, null);
         builder.addDoubleProperty("Voltage", this::takeMeasurement, null);
-	}
+    }
 }


### PR DESCRIPTION
Removed my comment stating who wrote the code and the date (me, on feb 8th), because Github does this automatically, and this comment could cause confusion if someone else makes changes to my code.