### PR TITLE
Motor Current Limiter (Issue #13)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2020.1.2"
+    id "edu.wpi.first.GradleRIO" version "2020.3.2"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -40,8 +40,6 @@ public class Robot extends TimedRobot {
     //flag to indicate the real match
     private Boolean bRealMatch;
 
-    //create variable for current monitoring
-    double motorCurrent;
 
     /**
      * Determines if the robot is in a real match.
@@ -144,9 +142,9 @@ public class Robot extends TimedRobot {
         SmartDashboard.putNumber("Pigeon Yaw", DriveBase.getInstance().getCurrentAngle());
         CommandScheduler.getInstance().run();
 
-        //Send motor current levels to shuffleboard.
-        motorCurrent = DriveBase.leftFrontTalon.getSupplyCurrent();
-		SmartDashboard.putNumber("Current (Front Left)", motorCurrent);
+        //The following 2 methods run Drivebase methods that tell shuffleboard what the motor current draw is and if motor current limiting is active.
+        DriveBase.getMotorCurrent();
+        DriveBase.isMotorLimitActive();
     }
 
     /**
@@ -200,6 +198,12 @@ public class Robot extends TimedRobot {
      */
     @Override
     public void teleopPeriodic() {
+        //If motor current limiting is active, trigger driver feedback (notify driver that drivetrain power is reduced).
+        if (DriveBase.isMotorLimitActive() == true) {
+            //TODO: Put driver feedback code here. Consult with drive team's preferences.
+        } else {
+            //Disable current limit driver feedback here.
+        }
     }
 
     @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -141,9 +141,9 @@ public class Robot extends TimedRobot {
         SmartDashboard.putNumber("Pigeon Yaw", DriveBase.getInstance().getCurrentAngle());
         CommandScheduler.getInstance().run();
 
-        //The following 2 methods run Drivebase methods that tell shuffleboard what the motor current draw is and if motor current limiting is active.
-        DriveBase.getMotorCurrent();
-        DriveBase.isMotorLimitActive();
+        //The following 2 lines run Drivebase methods that tell shuffleboard what the motor current draw is and if motor current limiting is active.
+        DriveBase.getInstance().getMotorCurrent();
+        DriveBase.getInstance().isMotorLimitActive();
     }
 
     /**
@@ -198,10 +198,10 @@ public class Robot extends TimedRobot {
     @Override
     public void teleopPeriodic() {
         //If motor current limiting is active, trigger driver feedback (notify driver that drivetrain power is reduced).
-        if (DriveBase.isMotorLimitActive() == true) {
+        if (DriveBase.getInstance().isMotorLimitActive() == true) {
             //TODO: Put driver feedback code here. Consult with drive team's preferences.
             
-            //Example driver feedback (if you wish to use this, import joystick and RumbleType libraries)
+            //Example driver feedback (if you wish to use this, import joystick and RumbleType libraries):
             //joystick.setRumble(RumbleType.kLeftRumble, 0.5);
             //joystick.setRumble(RumbleType.kRightRumble, 0.5);
         } else {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -7,10 +7,6 @@
 
 package frc.robot;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.logging.Logger;
-
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -20,6 +16,10 @@ import frc.robot.config.Config;
 import frc.robot.nettables.ControlCtrlNetTable;
 import frc.robot.nettables.VisionCtrlNetTable;
 import frc.robot.subsystems.DriveBase;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.logging.Logger;
 
 /**
  * The VM is configured to automatically run this class, and to call the functions corresponding to
@@ -39,7 +39,6 @@ public class Robot extends TimedRobot {
     private Boolean bFromTeleMode;
     //flag to indicate the real match
     private Boolean bRealMatch;
-
 
     /**
      * Determines if the robot is in a real match.
@@ -201,8 +200,14 @@ public class Robot extends TimedRobot {
         //If motor current limiting is active, trigger driver feedback (notify driver that drivetrain power is reduced).
         if (DriveBase.isMotorLimitActive() == true) {
             //TODO: Put driver feedback code here. Consult with drive team's preferences.
+            
+            //Example driver feedback (if you wish to use this, import joystick and RumbleType libraries)
+            //joystick.setRumble(RumbleType.kLeftRumble, 0.5);
+            //joystick.setRumble(RumbleType.kRightRumble, 0.5);
         } else {
-            //Disable current limit driver feedback here.
+            //Turn off driver feedback for the current limiter once the current limiter turns off. Example:
+            //joystick.setRumble(RumbleType.kLeftRumble, 0);
+            //joystick.setRumble(RumbleType.kRightRumble, 0);
         }
     }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -7,6 +7,10 @@
 
 package frc.robot;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.logging.Logger;
+
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -16,10 +20,6 @@ import frc.robot.config.Config;
 import frc.robot.nettables.ControlCtrlNetTable;
 import frc.robot.nettables.VisionCtrlNetTable;
 import frc.robot.subsystems.DriveBase;
-
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.logging.Logger;
 
 /**
  * The VM is configured to automatically run this class, and to call the functions corresponding to
@@ -39,6 +39,9 @@ public class Robot extends TimedRobot {
     private Boolean bFromTeleMode;
     //flag to indicate the real match
     private Boolean bRealMatch;
+
+    //create variable for current monitoring
+    double motorCurrent;
 
     /**
      * Determines if the robot is in a real match.
@@ -118,7 +121,7 @@ public class Robot extends TimedRobot {
         bFromTeleMode = false;
         bRealMatch = false;
 
-        logger.addHandler(Config.logFileHandler);
+        logger.addHandler(Config.logFileHandler);   
 
     }
 
@@ -140,6 +143,10 @@ public class Robot extends TimedRobot {
         SmartDashboard.putNumber("PowerCell Distance", VisionCtrlNetTable.distanceToPowerCell.get());
         SmartDashboard.putNumber("Pigeon Yaw", DriveBase.getInstance().getCurrentAngle());
         CommandScheduler.getInstance().run();
+
+        //Send motor current levels to shuffleboard.
+        motorCurrent = DriveBase.leftFrontTalon.getSupplyCurrent();
+		SmartDashboard.putNumber("Current (Front Left)", motorCurrent);
     }
 
     /**

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -141,7 +141,21 @@ public class Config {
             .registerToTable(Config.constantsTable);
     public static FluidConstant<Double> maxYawErrorOuterPortCommand = new FluidConstant<>("Outer Port Command Yaw Error", 3.0)
             .registerToTable(Config.constantsTable);
+
+    // Current limiter values
+    public static final int kPeakCurrentAmps = 60; //Peak current threshold to trigger the current limit
+        
+    public static final int kPeakTimeMs = 500; /* Time after current exceeds peak current to trigger current limit */
+
+    public static final int kContinCurrentAmps = 40; /* Current to mantain once current limit has been triggered */
     
+    /**
+     * Timeout value generally used in parameter configs
+     * Non-zero to block the config until success, zero to skip checking 
+     */
+    public static final int kTimeoutMs = 30;
+
+
     /**
      * Returns one of the values passed based on the robot ID
      *

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -145,15 +145,9 @@ public class Config {
     // Current limiter values
     public static final int kPeakCurrentAmps = 60; //Peak current threshold to trigger the current limit
         
-    public static final int kPeakTimeMs = 500; /* Time after current exceeds peak current to trigger current limit */
+    public static final double kPeakTimeSec = 1.0; /* Time after current exceeds peak current to trigger current limit */
 
     public static final int kContinCurrentAmps = 40; /* Current to mantain once current limit has been triggered */
-    
-    /**
-     * Timeout value generally used in parameter configs
-     * Non-zero to block the config until success, zero to skip checking 
-     */
-    public static final int kTimeoutMs = 30;
 
 
     /**

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -142,12 +142,12 @@ public class Config {
     public static FluidConstant<Double> maxYawErrorOuterPortCommand = new FluidConstant<>("Outer Port Command Yaw Error", 3.0)
             .registerToTable(Config.constantsTable);
 
-    // Current limiter values
-    public static final int kPeakCurrentAmps = 60; //Peak current threshold to trigger the current limit
+    // Current limiter Constants
+    public static final int PEAK_CURRENT_AMPS = 60; //Peak current threshold to trigger the current limit
         
-    public static final double kPeakTimeSec = 1.0; /* Time after current exceeds peak current to trigger current limit */
+    public static final double PEAK_TIME_SEC = 1.0; //Time after current exceeds peak current to trigger current limit
 
-    public static final int kContinCurrentAmps = 40; /* Current to mantain once current limit has been triggered */
+    public static final int CONTIN_CURRENT_AMPS = 40; //Current to mantain once current limit has been triggered
 
 
     /**

--- a/src/main/java/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase.java
@@ -36,8 +36,7 @@ public class DriveBase extends SubsystemBase {
     private DriveMode driveMode;
 
     // The drivebase talons
-    private static WPI_TalonSRX leftFrontTalon, leftRearTalon, rightFrontTalon, rightRearTalon, talon5plyboy;
-    //Talons were made static so that their current levels can be checked in static Driverbase methods.
+    private WPI_TalonSRX leftFrontTalon, leftRearTalon, rightFrontTalon, rightRearTalon, talon5plyboy;
 
     //create variable to display motor current levels
     public static double motorCurrent;
@@ -83,15 +82,15 @@ public class DriveBase extends SubsystemBase {
 
     }
 
-    public static double getMotorCurrent() {
-        motorCurrent = DriveBase.leftFrontTalon.getSupplyCurrent();
+    public double getMotorCurrent() {
+        motorCurrent = leftFrontTalon.getSupplyCurrent();
 
         SmartDashboard.putNumber("MotorCurrent (FrontLeft)", motorCurrent);
         
         return(motorCurrent);
     }
 
-    public static boolean isMotorLimitActive() {
+    public boolean isMotorLimitActive() {
         //Check if motor current limiting is active (is current draw over or at current limit)
         if (motorCurrent >= Config.CONTIN_CURRENT_AMPS) {
             motorLimitActive = true;

--- a/src/main/java/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase.java
@@ -35,7 +35,8 @@ public class DriveBase extends SubsystemBase {
     private DriveMode driveMode;
 
     // The drivebase talons
-    private WPI_TalonSRX leftFrontTalon, leftRearTalon, rightFrontTalon, rightRearTalon, talon5plyboy;
+    public static WPI_TalonSRX leftFrontTalon, leftRearTalon, rightFrontTalon, rightRearTalon, talon5plyboy;
+    //These talons have been made public and static so that their current levels can be checked in Robot.java by using periodic functions.
 
     public boolean sensitiveSteering = false;
 
@@ -44,8 +45,9 @@ public class DriveBase extends SubsystemBase {
     public static FluidConstant<Double> DRIVETRAIN_SENSITIVE_MAX_SPEED = new FluidConstant<>("DrivetrainSensitiveMaxSpeed", 0.2)
             .registerToTable(Config.constantsTable);
 
-    private DriveBase() {
+    boolean MOTOR_CURRENT_LIMIT = true; //Enable/disable motor current limiting. Not intended to change during robot operation.
 
+    private DriveBase() { 
         // Initialize the talons
         leftFrontTalon = new WPI_TalonSRX(Config.LEFT_FRONT_TALON);
         leftRearTalon = new WPI_TalonSRX(Config.LEFT_REAR_TALON);
@@ -53,6 +55,27 @@ public class DriveBase extends SubsystemBase {
         rightRearTalon = new WPI_TalonSRX(Config.RIGHT_REAR_TALON);
 
         SmartDashboard.putNumber("Right Front Talon", Config.RIGHT_FRONT_TALON);
+
+        //Set up the current limiter for all motors:
+        leftFrontTalon.configPeakCurrentLimit(Config.kPeakCurrentAmps, Config.kTimeoutMs);
+		leftFrontTalon.configPeakCurrentDuration(Config.kPeakTimeMs, Config.kTimeoutMs);
+		leftFrontTalon.configContinuousCurrentLimit(Config.kContinCurrentAmps, Config.kTimeoutMs);
+        leftFrontTalon.enableCurrentLimit(MOTOR_CURRENT_LIMIT); // Honor initial setting
+        
+        leftRearTalon.configPeakCurrentLimit(Config.kPeakCurrentAmps, Config.kTimeoutMs);
+		leftRearTalon.configPeakCurrentDuration(Config.kPeakTimeMs, Config.kTimeoutMs);
+		leftRearTalon.configContinuousCurrentLimit(Config.kContinCurrentAmps, Config.kTimeoutMs);
+        leftRearTalon.enableCurrentLimit(MOTOR_CURRENT_LIMIT); // Honor initial setting
+        
+        rightFrontTalon.configPeakCurrentLimit(Config.kPeakCurrentAmps, Config.kTimeoutMs);
+		rightFrontTalon.configPeakCurrentDuration(Config.kPeakTimeMs, Config.kTimeoutMs);
+		rightFrontTalon.configContinuousCurrentLimit(Config.kContinCurrentAmps, Config.kTimeoutMs);
+        rightFrontTalon.enableCurrentLimit(MOTOR_CURRENT_LIMIT); // Honor initial setting
+
+        rightRearTalon.configPeakCurrentLimit(Config.kPeakCurrentAmps, Config.kTimeoutMs);
+		rightRearTalon.configPeakCurrentDuration(Config.kPeakTimeMs, Config.kTimeoutMs);
+		rightRearTalon.configContinuousCurrentLimit(Config.kContinCurrentAmps, Config.kTimeoutMs);
+        rightRearTalon.enableCurrentLimit(MOTOR_CURRENT_LIMIT); // Honor initial setting
 
         talon5plyboy = new WPI_TalonSRX(Config.TALON_5_PLYBOY);
 

--- a/src/main/java/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase.java
@@ -63,11 +63,11 @@ public class DriveBase extends SubsystemBase {
 
         SmartDashboard.putNumber("Right Front Talon", Config.RIGHT_FRONT_TALON);
 
-        //Set up the current limiter for all motors (limits current SUPPLY).        Enabled? True/false /         Limit (A)        /Surge trigger level (A) /  Max Surge time (sec)
-        leftFrontTalon.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(EN_MOTOR_CURRENT_LIM, Config.kContinCurrentAmps, Config.kPeakCurrentAmps, Config.kPeakTimeSec));
-		leftRearTalon.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(EN_MOTOR_CURRENT_LIM, Config.kContinCurrentAmps, Config.kPeakCurrentAmps, Config.kPeakTimeSec));
-		rightFrontTalon.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(EN_MOTOR_CURRENT_LIM, Config.kContinCurrentAmps, Config.kPeakCurrentAmps, Config.kPeakTimeSec));
-		rightRearTalon.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(EN_MOTOR_CURRENT_LIM, Config.kContinCurrentAmps, Config.kPeakCurrentAmps, Config.kPeakTimeSec));
+        //Set up the current limiter for all motors (limits current SUPPLY).        Enabled? True/false /         Limit (A)         /Surge trigger level (A) /  Max Surge time (sec)
+        leftFrontTalon.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(EN_MOTOR_CURRENT_LIM, Config.CONTIN_CURRENT_AMPS, Config.PEAK_CURRENT_AMPS, Config.PEAK_TIME_SEC));
+		leftRearTalon.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(EN_MOTOR_CURRENT_LIM, Config.CONTIN_CURRENT_AMPS, Config.PEAK_CURRENT_AMPS, Config.PEAK_TIME_SEC));
+		rightFrontTalon.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(EN_MOTOR_CURRENT_LIM, Config.CONTIN_CURRENT_AMPS, Config.PEAK_CURRENT_AMPS, Config.PEAK_TIME_SEC));
+		rightRearTalon.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(EN_MOTOR_CURRENT_LIM, Config.CONTIN_CURRENT_AMPS, Config.PEAK_CURRENT_AMPS, Config.PEAK_TIME_SEC));
 		        
         talon5plyboy = new WPI_TalonSRX(Config.TALON_5_PLYBOY);
 
@@ -93,14 +93,14 @@ public class DriveBase extends SubsystemBase {
 
     public static boolean isMotorLimitActive() {
         //Check if motor current limiting is active (is current draw over or at current limit)
-        if (motorCurrent > Config.kContinCurrentAmps - 1) {
+        if (motorCurrent >= Config.CONTIN_CURRENT_AMPS) {
             motorLimitActive = true;
         }
         else {
             motorLimitActive = false;
         }
 
-        //Regardless of whether motor current limiting is active, tell shuffleboard and return the result.
+        //Regardless of whether motor current limiting is active or not, tell shuffleboard and return the result.
         SmartDashboard.putBoolean("MotorCurrentLimit T/F", motorLimitActive);
 
         return(motorLimitActive);

--- a/src/main/java/frc/robot/subsystems/SubsystemOperation.java
+++ b/src/main/java/frc/robot/subsystems/SubsystemOperation.java
@@ -1,0 +1,69 @@
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj.DriverStation;
+
+import java.util.function.Supplier;
+
+public class SubsystemOperation {
+    // A function that represents when the operation is applicable to the subsystem
+    private Supplier<Boolean> applicable;
+    
+    /**
+     * A static class with some pre-defined applicable states for ease-of-use
+     */
+    public static class State {
+        public static final Supplier<Boolean> TELEOP = () -> DriverStation.getInstance().isOperatorControl();
+        public static final Supplier<Boolean> AUTO = () -> DriverStation.getInstance().isAutonomous();
+        public static final Supplier<Boolean> TELEOP_OR_AUTO = () -> TELEOP.get() || AUTO.get();
+        public static final Supplier<Boolean> ALWAYS = () -> true;
+    }
+    
+    // The name given to this operation
+    private String name;
+    
+    // The state of this operation
+    private boolean enabled;
+    
+    /**
+     * Constructor for a operation. DO NOT USE THIS TO MAKE A operation YOURSELF.
+     * Use the {@code SubsystemOperationManager.createOperation} method instead!
+     * @param name The name of the operation
+     * @param applicable The options for this operation
+     * @param startEnabled The start state of this operation
+     */
+    public SubsystemOperation(String name, Supplier<Boolean> applicable, boolean startEnabled) {
+        this.name = name;
+        this.applicable = applicable;
+        this.enabled = startEnabled;
+    }
+    
+    /**
+     * Setter for if this operation is enabled
+     * @param enabled enabled?
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+    
+    /**
+     * @return is this operation is enabled?
+     */
+    public boolean getEnabled() {
+        return this.enabled;
+    }
+    
+    /**
+     * @return This operation's name
+     */
+    public String getName() {
+        return this.name;
+    }
+    
+    /**
+     * Checks the operation's applicable state
+     * @return True if the operation is applicable
+     */
+    public boolean isApplicable() {
+        return applicable.get();
+    }
+}

--- a/src/main/java/frc/robot/subsystems/SubsystemOperationManager.java
+++ b/src/main/java/frc/robot/subsystems/SubsystemOperationManager.java
@@ -1,0 +1,64 @@
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.function.Supplier;
+
+/**
+ * A SubsystemOperationManager manages a list of operations required for this subsystem to run.
+ * Commands and other subsystems can register operations and the owner of the manager can check if they are satisfied.
+ */
+public class SubsystemOperationManager {
+    // A list of all the Operations for this operation manager
+    private HashSet<SubsystemOperation> operations = new HashSet<>();
+    
+    // Name for debugging
+    private String name;
+    
+    /**
+     * Creates a new operation manager.
+     * @param name The name of this manager for debugging
+     */
+    public SubsystemOperationManager(String name) {
+        this.name = name;
+    }
+    
+    /**
+     * Creates a new operation and automatically registers it with this manager
+     * @param name The name of the operation
+     * @param applicable A function representing when this operation is applicable to the subsystem
+     * @param startEnabled If this operation starts enabled
+     * @return The new operation ready to use
+     */
+    public SubsystemOperation createOperation(String name, Supplier<Boolean> applicable, boolean startEnabled) {
+        SubsystemOperation newOperation = new SubsystemOperation(name, applicable, startEnabled);
+        operations.add(newOperation);
+        return newOperation;
+    }
+    
+    /**
+     * Checks if all the operations are satisfied and this subsystem is allowed to run
+     * @return true if all the operations that match the options are satisfied, false otherwise
+     */
+    public boolean allSatisfied() {
+        // For all the operations, make sure the ones that match the provided options are enabled
+        return operations.stream().noneMatch(c ->
+                // Only match if the operation is false and the operation is applicable
+                !c.getEnabled() && c.isApplicable()
+        );
+    }
+    
+    /**
+     * This is for debug, it will send all the operations registered to the dashboard to help figure out why a
+     * subsystem isn't running
+     */
+    public void sendOperationsToDashboard() {
+        ArrayList<String> data = new ArrayList<>();
+        for (var operation : operations) {
+            data.add(operation.getName() + ": " + operation.getEnabled());
+        }
+        SmartDashboard.putStringArray(this.name + " operation", data.toArray(new String[0]));
+    }
+}

--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix.json",
     "name": "CTRE-Phoenix",
-    "version": "5.17.3",
+    "version": "5.18.2",
     "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
     "mavenUrls": [
         "http://devsite.ctr-electronics.com/maven/release/"
@@ -11,19 +11,19 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-java",
-            "version": "5.17.3"
+            "version": "5.18.2"
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-java",
-            "version": "5.17.3"
+            "version": "5.18.2"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.17.3",
+            "version": "5.18.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -35,7 +35,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "diagnostics",
-            "version": "5.17.3",
+            "version": "5.18.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -47,7 +47,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "canutils",
-            "version": "5.17.3",
+            "version": "5.18.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "platform-stub",
-            "version": "5.17.3",
+            "version": "5.18.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -69,7 +69,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "core",
-            "version": "5.17.3",
+            "version": "5.18.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -83,7 +83,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-cpp",
-            "version": "5.17.3",
+            "version": "5.18.2",
             "libName": "CTRE_Phoenix_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-cpp",
-            "version": "5.17.3",
+            "version": "5.18.2",
             "libName": "CTRE_Phoenix",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -111,7 +111,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.17.3",
+            "version": "5.18.2",
             "libName": "CTRE_PhoenixCCI",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -125,7 +125,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "diagnostics",
-            "version": "5.17.3",
+            "version": "5.18.2",
             "libName": "CTRE_PhoenixDiagnostics",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -139,7 +139,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "canutils",
-            "version": "5.17.3",
+            "version": "5.18.2",
             "libName": "CTRE_PhoenixCanutils",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -152,7 +152,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "platform-stub",
-            "version": "5.17.3",
+            "version": "5.18.2",
             "libName": "CTRE_PhoenixPlatform",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -165,7 +165,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "core",
-            "version": "5.17.3",
+            "version": "5.18.2",
             "libName": "CTRE_PhoenixCore",
             "headerClassifier": "headers",
             "sharedLibrary": false,

--- a/vendordeps/REVColorSensorV3.json
+++ b/vendordeps/REVColorSensorV3.json
@@ -1,7 +1,7 @@
 {
     "fileName": "REVColorSensorV3.json",
     "name": "REVColorSensorV3",
-    "version": "1.0.1",
+    "version": "1.2.0",
     "uuid": "cda7b4b1-d003-44ac-a1ef-485c1347059a",
     "mavenUrls": [
         "http://www.revrobotics.com/content/sw/color-sensor-v3/sdk/maven/"
@@ -11,7 +11,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "ColorSensorV3-java",
-            "version": "1.0.1"
+            "version": "1.2.0"
         }
     ],
     "jniDependencies": [],
@@ -19,7 +19,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "ColorSensorV3-cpp",
-            "version": "1.0.1",
+            "version": "1.2.0",
             "libName": "ColorSensorV3",
             "headerClassifier": "headers",
             "sourcesClassifier": "source",

--- a/vendordeps/WPILibOldCommands.json
+++ b/vendordeps/WPILibOldCommands.json
@@ -1,0 +1,37 @@
+{
+    "fileName": "WPILibOldCommands.json",
+    "name": "WPILib-Old-Commands",
+    "version": "2020.0.0",
+    "uuid": "b066afc2-5c18-43c4-b758-43381fcb275e",
+    "mavenUrls": [],
+    "jsonUrl": "",
+    "javaDependencies": [
+        {
+            "groupId": "edu.wpi.first.wpilibOldCommands",
+            "artifactId": "wpilibOldCommands-java",
+            "version": "wpilib"
+        }
+    ],
+    "jniDependencies": [],
+    "cppDependencies": [
+        {
+            "groupId": "edu.wpi.first.wpilibOldCommands",
+            "artifactId": "wpilibOldCommands-cpp",
+            "version": "wpilib",
+            "libName": "wpilibOldCommands",
+            "headerClassifier": "headers",
+            "sourcesClassifier": "sources",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "linuxraspbian",
+                "linuxaarch64bionic",
+                "windowsx86-64",
+                "windowsx86",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Code limits motor current draw to 40 amps (continuously). Current that exceeds 60 amps for more than a second will be clamped down to 40. Code sends motor current info to Shuffleboard. Code can trigger driver feedback in teleopPeriodic if desired.

The changes to files other than Robot.java, Drivebase.java, and Config.java occurred when I updated my local vendor libraries - let me know if this isn't OK.