### PR TITLE
Motor Current Limiter 2 (Issue #13)

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -16,6 +16,7 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.robot.config.Config;
 import frc.robot.nettables.ControlCtrlNetTable;
 import frc.robot.nettables.VisionCtrlNetTable;
+import frc.robot.subsystems.DriveBase2020;
 import frc.robot.subsystems.DriveBaseHolder;
 import frc.robot.sensors.AnalogSelector;
 
@@ -145,6 +146,10 @@ public class Robot extends TimedRobot {
         SmartDashboard.putNumber("PowerCell Distance", VisionCtrlNetTable.distanceToPowerCell.get());
         SmartDashboard.putNumber("Pigeon Yaw", DriveBaseHolder.getInstance().getCurrentAngle());
         CommandScheduler.getInstance().run();
+
+        //The following 2 lines run Drivebase methods that tell shuffleboard what the motor current draw is and if motor current limiting is active.
+        DriveBase2020.getInstance().getMotorCurrent();
+        DriveBase2020.getInstance().isMotorLimitActive();
     }
 
     /**
@@ -198,6 +203,18 @@ public class Robot extends TimedRobot {
      */
     @Override
     public void teleopPeriodic() {
+        //If motor current limiting is active, trigger driver feedback (notify driver that drivetrain power is reduced).
+        if (DriveBase2020.getInstance().isMotorLimitActive() == true) {
+            //TODO: Put driver feedback code here. Consult with drive team's preferences.
+            
+            //Example driver feedback (if you wish to use this, import joystick and RumbleType libraries):
+            //joystick.setRumble(RumbleType.kLeftRumble, 0.5);
+            //joystick.setRumble(RumbleType.kRightRumble, 0.5);
+        } else {
+            //Turn off driver feedback for the current limiter once the current limiter turns off. Example:
+            //joystick.setRumble(RumbleType.kLeftRumble, 0);
+            //joystick.setRumble(RumbleType.kRightRumble, 0);
+        }
     }
 
     @Override

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -83,6 +83,12 @@ public class Config {
     public static int SHOOTER_MOTOR = robotSpecific(5, 5, -1, -1, 16); //protobot is 16
     public static int CLIMBER_TALON = robotSpecific(10, 10, -1, -1, 16);
 
+    // Current limiter Constants
+    public static int PEAK_CURRENT_AMPS = 60; //Peak current threshold to trigger the current limit
+    public static double PEAK_TIME_SEC = 1.0; //Time after current exceeds peak current to trigger current limit
+    public static int CONTIN_CURRENT_AMPS = 40; //Current to mantain once current limit has been triggered 
+    public static boolean MOTOR_CURRENT_LIMIT = true; //Enable or disable motor current limiting.
+
     public static int TALON_5_PLYBOY = robotSpecific(-1, -1, -1, -1, -1, 5);
     public static int PIGEON_ID = robotSpecific(CLIMBER_TALON, -1, RIGHT_REAR_MOTOR, LEFT_FRONT_MOTOR, LEFT_REAR_MOTOR, TALON_5_PLYBOY);
     

--- a/src/main/java/frc/robot/subsystems/DriveBase2020.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase2020.java
@@ -6,9 +6,12 @@ import com.ctre.phoenix.motorcontrol.IMotorController;
 import com.ctre.phoenix.motorcontrol.can.BaseMotorController;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 import com.ctre.phoenix.motorcontrol.can.WPI_VictorSPX;
+import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
 import com.ctre.phoenix.sensors.PigeonIMU;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import frc.robot.config.Config;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 import java.util.Arrays;
 import java.util.List;
@@ -19,6 +22,12 @@ import java.util.stream.Collectors;
 public class DriveBase2020 extends DriveBase {
     WPI_TalonSRX leftMaster, rightMaster, climberTalon;
     WPI_VictorSPX leftSlave, rightSlave;
+
+    // DriveBase2020 is a singleton class as it represents a physical subsystem
+    private static DriveBase2020 currentInstance;
+
+    public double motorCurrent; //variable to display motor current levels
+    public boolean motorLimitActive = false; //states if motor current is actively being limited
     
     public DriveBase2020() {
         leftMaster = new WPI_TalonSRX(Config.LEFT_FRONT_MOTOR);
@@ -27,11 +36,51 @@ public class DriveBase2020 extends DriveBase {
         rightSlave = new WPI_VictorSPX(Config.RIGHT_REAR_MOTOR);
         climberTalon = new WPI_TalonSRX(Config.CLIMBER_TALON);
         differentialDrive = new DifferentialDrive(leftMaster, rightMaster);
-        
+
+        //Current limiting for drivetrain master motors (limits current SUPPLY).    Enabled? True/false   /         Limit (A)         / Surge trigger level (A) /  Max Surge time (sec)
+        leftMaster.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(Config.MOTOR_CURRENT_LIMIT, Config.CONTIN_CURRENT_AMPS, Config.PEAK_CURRENT_AMPS, Config.PEAK_TIME_SEC));
+        rightMaster.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(Config.MOTOR_CURRENT_LIMIT, Config.CONTIN_CURRENT_AMPS, Config.PEAK_CURRENT_AMPS, Config.PEAK_TIME_SEC));
+
         if (Config.PIGEON_ID != -1) {
             pigeon = new PigeonIMU(new WPI_TalonSRX(Config.PIGEON_ID));
             pigeon.setFusedHeading(0d, Config.CAN_TIMEOUT_LONG);
         }
+    }
+
+    public double getMotorCurrent() {
+        motorCurrent = leftMaster.getSupplyCurrent();
+
+        //Send motor current to shuffleboard and return it
+        SmartDashboard.putNumber("MotorCurrent (FrontLeft)", motorCurrent);
+        return(motorCurrent);
+    }
+
+    public boolean isMotorLimitActive() {
+        //Check if motor current limiting is active (is current draw over or at current limit)
+        if (motorCurrent >= Config.CONTIN_CURRENT_AMPS) {
+            motorLimitActive = true;
+        }
+        else {
+            motorLimitActive = false;
+        }
+
+        //Tell shuffleboard if current limting is active and return the result.
+        SmartDashboard.putBoolean("MotorCurrentLimit T/F", motorLimitActive);
+        return(motorLimitActive);
+    }
+
+    /**
+     * Initialize the current DriveBase instance
+     */
+    public static void init() {
+        if (currentInstance == null) {
+            currentInstance = new DriveBase2020();
+        }
+    }
+
+    public static DriveBase2020 getInstance() {
+        init();
+        return currentInstance;
     }
     
     @Override


### PR DESCRIPTION
By default, code limits motor current draw to 40 amps continuously. Current that exceeds 60 amps for more than a second will be clamped down to 40. These values can be changed in Config.java.

Code sends the current draw values to Shuffleboard. Driver feedback, currently a true/false box in Shuffleboard, will warn the driver when current limiting is active and drivetrain power is reduced.

I rewrote my code on a new, up-to-date branch to resolve merge conflicts (my old branch was far behind, so I started over).